### PR TITLE
fix: improve guildchat logger

### DIFF
--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -3,7 +3,7 @@ const { WebhookClient, Util, Message } = require('discord.js');
 const hook = new WebhookClient(process.env.WEBHOOK_ID, process.env.WEBHOOK_TOKEN);
 
 module.exports = function chat(bot, username, message, translate, jsonMsg, matches) {
-  if (jsonMsg.extra === undefined) return;
+  if (!jsonMsg.extra) return;
   if (!jsonMsg.extra[0].text.startsWith('§2Guild > ')) return;
   
   const i = message.indexOf(":");

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -1,4 +1,4 @@
-const { WebhookClient, Util, Message } = require('discord.js');
+const { WebhookClient, Util, MessageEmbed } = require('discord.js');
 
 const hook = new WebhookClient(process.env.WEBHOOK_ID, process.env.WEBHOOK_TOKEN);
 
@@ -9,7 +9,7 @@ module.exports = function chat(bot, username, message, translate, jsonMsg, match
   const i = message.indexOf(":");
   if (i === -1) return; // no colon, so it's a join/leave message
 
-  const name = message.slice(8, i); // slice guild prefix off
+  const name = message.slice(0, i); // slice guild prefix off
   const usrMsg = Util.removeMentions(Util.escapeMarkdown(message.slice(i + 2))); // remove mentions, escape markdown, and slice name off
 
   const j = name.indexOf("] ");

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -9,7 +9,7 @@ module.exports = function chat(bot, username, message, translate, jsonMsg, match
   const i = message.indexOf(":");
   if (i === -1) return; // no colon, so it's a join/leave message
 
-  const name = message.slice(0, i); // slice guild prefix off
+  const name = message.slice(0, i);
   const usrMsg = Util.removeMentions(Util.escapeMarkdown(message.slice(i + 2))); // remove mentions, escape markdown, and slice name off
 
   const j = name.indexOf("] ");


### PR DESCRIPTION
- Fixes bug where user message is cut off after a `:` if they include one in their mesage
- Fixes crashing bug
- Fixes rank colors not being accurate
- Adds hypixel moderator rank color
- Improves performance by using slices instead of splits for string manipulation
- Cleanes up code

Fully working with all username cases. (if they have guild/hypixel rank or not)